### PR TITLE
Fix Jolpica round fallback

### DIFF
--- a/livef1/models/meeting.py
+++ b/livef1/models/meeting.py
@@ -133,6 +133,14 @@ class Meeting:
             return year
         raise ValueError("Meeting needs a linked season or a year to probe API availability.")
 
+    @property
+    def jolpica_round(self):
+        for attr in ("round", "number"):
+            value = getattr(self, attr, None)
+            if value is not None:
+                return value
+        return None
+
     def _check_if_jolpica_available(self):
         """
         Checks if this meeting's name appears as a Jolpica ``race_name`` for the season year.
@@ -243,7 +251,7 @@ class Meeting:
     def driverStandings(self):
         if not self.is_jolpica_available or self.season is None:
             return None
-        n = getattr(self, "number", None)
+        n = self.jolpica_round
         if n is None:
             return None
         raw = (
@@ -260,7 +268,7 @@ class Meeting:
     def constructorStandings(self):
         if not self.is_jolpica_available or self.season is None:
             return None
-        n = getattr(self, "number", None)
+        n = self.jolpica_round
         if n is None:
             return None
         raw = (

--- a/livef1/models/session.py
+++ b/livef1/models/session.py
@@ -155,6 +155,18 @@ class Session:
         )
         return self.is_jolpica_available
 
+    def _jolpica_round(self):
+        if self.meeting is None:
+            return None
+        value = getattr(self.meeting, "jolpica_round", None)
+        if value is not None:
+            return value
+        for attr in ("round", "number"):
+            value = getattr(self.meeting, attr, None)
+            if value is not None:
+                return value
+        return None
+
     def _load_default_silver_tables(self):
         for table_name in SILVER_SESSION_TABLES:
             self.create_silver_table(table_name, TABLE_REQUIREMENTS[table_name], include_session=True)(globals()[TABLE_GENERATION_FUNCTIONS[table_name]])
@@ -170,7 +182,13 @@ class Session:
 
         This method loads the session data by fetching the topic names and drivers.
         """
-        if self.is_livetiming_available: self.get_topic_names()
+        if self.is_livetiming_available or hasattr(self, "full_path"):
+            try:
+                self.get_topic_names()
+                self.is_livetiming_available = True
+            except Exception:
+                if self.is_livetiming_available:
+                    raise
         if self.is_jolpica_available or self.is_livetiming_available: self._load_drivers()
         if self.is_jolpica_available:
             if not hasattr(self, "driverStandings"):
@@ -297,8 +315,9 @@ class Session:
             )
         else: data_livetiming = {}
 
-        if self.is_jolpica_available:
-            drivers_jolpica = jolpica_client.query().season(self.season.year).round(self.meeting.round).get_drivers(limit=100).data.drivers
+        round_number = self._jolpica_round()
+        if self.is_jolpica_available and round_number is not None:
+            drivers_jolpica = jolpica_client.query().season(self.season.year).round(round_number).get_drivers(limit=100).data.drivers
             data_jolpica = {}
             for driver in drivers_jolpica:
                 if driver.permanent_number is not None:
@@ -900,12 +919,18 @@ class Session:
             logger.info(f"Starting grid have been loaded and saved to 'session.startingGrid'.")
 
     def _load_driver_standings(self):
-        driver_standings = jolpica_client.query().season(self.season.year).round(self.meeting.round).get_driver_standings(limit=100).data.standings_lists[0].to_dict()["DriverStandings"]
+        round_number = self._jolpica_round()
+        if round_number is None:
+            return
+        driver_standings = jolpica_client.query().season(self.season.year).round(round_number).get_driver_standings(limit=100).data.standings_lists[0].to_dict()["DriverStandings"]
         self.driverStandings = parse_driver_standings(self.meeting.season, driver_standings)
         logger.info(f"Driver standings have been loaded and saved to 'session.driverStandings'.")
 
     def _load_constructor_standings(self):
-        rows = jolpica_client.query().season(self.season.year).round(self.meeting.round).get_constructor_standings(limit=100).data.standings_lists[0].to_dict()["ConstructorStandings"]
+        round_number = self._jolpica_round()
+        if round_number is None:
+            return
+        rows = jolpica_client.query().season(self.season.year).round(round_number).get_constructor_standings(limit=100).data.standings_lists[0].to_dict()["ConstructorStandings"]
         self.constructorStandings = parse_constructor_standings(self.meeting.season, rows)
         logger.info("Constructor standings have been loaded and saved to 'session.constructorStandings'.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,8 @@ dependencies = [
     "ujson>=5.10.0",
     "websockets>=13.0.1",
 ]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.15.16",
+]

--- a/tests/test_models_session.py
+++ b/tests/test_models_session.py
@@ -1,6 +1,7 @@
 """Tests for livef1.models.session.Session."""
 import pytest
 import pandas as pd
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 from livef1.models.session import Session
 from livef1.data_processing.data_models import BronzeTable
@@ -77,6 +78,37 @@ def test_session_get_data_from_cache():
     result = session.get_data("TimingData", force=False)
     assert result is not None
     assert hasattr(result, "columns") or hasattr(result, "index")
+
+
+def test_session_load_drivers_uses_meeting_number_as_jolpica_round():
+    with patch("livef1.models.session.helper.build_session_endpoint", return_value="https://example.com/session"):
+        session = Session(key=9465, name="Race", path="x")
+    session.season = SimpleNamespace(year=2024)
+    session.meeting = SimpleNamespace(name="Bahrain Grand Prix", number=1)
+    session.is_livetiming_available = False
+    session.is_jolpica_available = True
+
+    driver = MagicMock()
+    driver.permanent_number = "1"
+    driver.to_dict.return_value = {
+        "driverId": "max_verstappen",
+        "permanentNumber": "1",
+        "code": "VER",
+        "givenName": "Max",
+        "familyName": "Verstappen",
+    }
+
+    query = MagicMock()
+    query.season.return_value = query
+    query.round.return_value = query
+    query.get_drivers.return_value = SimpleNamespace(data=SimpleNamespace(drivers=[driver]))
+
+    with patch("livef1.models.session.jolpica_client") as client:
+        client.query.return_value = query
+        session._load_drivers()
+
+    query.round.assert_called_once_with(1)
+    assert "1" in session.drivers
 
 
 def test_session_create_silver_table_decorator():

--- a/uv.lock
+++ b/uv.lock
@@ -446,7 +446,7 @@ wheels = [
 
 [[package]]
 name = "livef1"
-version = "1.1.107"
+version = "1.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "basef1" },
@@ -472,6 +472,11 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "basef1", specifier = ">=0.1.0" },
@@ -492,6 +497,9 @@ requires-dist = [
     { name = "ujson", specifier = ">=5.10.0" },
     { name = "websockets", specifier = ">=13.0.1" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.15.16" }]
 
 [[package]]
 name = "lxml"
@@ -992,6 +1000,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
+    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

  Fixes Jolpica round lookup for sessions whose meeting metadata has `number` but no `round`. #20

  ## Changes

  - Added a `Meeting.jolpica_round` fallback resolver.
  - Updated session Jolpica driver and standings queries to use the resolved round.
  - Made session data loading attempt Live Timing topic discovery when a session path exists.
  - Added a regression test for Jolpica driver loading with meeting `number` fallback.
  - Added `ruff` as a uv dev dependency.

  ## Validation

  - `uv run pytest` passes: `166 passed`